### PR TITLE
#13 [BE] 새로운 멤버 초대하기

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "consistent-return": "off",
     "no-underscore-dangle": "off",
     "no-param-reassign": "off",
-    "no-plusplus": "off"
+    "no-plusplus": "off",
+    "no-prototype-builtins": "off"
   }
 }

--- a/constants.js
+++ b/constants.js
@@ -13,4 +13,11 @@ const ERROR_MESSAGE = Object.freeze({
   NOT_VALID_USER: "해당 유저가 존재하지 않습니다.",
 });
 
-module.exports = ERROR_MESSAGE;
+const RESPONSE_MESSAGE = Object.freeze({
+  SENDING_SUCCESS: "메일 발송 성공",
+  ALREADY_IN_SAME_GROUP: "이미 같은 그룹 멤버입니다.",
+  ALREADY_INVITED: "이미 초대 메일을 보낸 유저입니다.",
+});
+
+exports.ERROR_MESSAGE = ERROR_MESSAGE;
+exports.RESPONSE_MESSAGE = RESPONSE_MESSAGE;

--- a/constants.js
+++ b/constants.js
@@ -10,6 +10,7 @@ const ERROR_MESSAGE = Object.freeze({
   RELOGIN_NEEDED: "재로그인이 필요한 유저입니다.",
   FORBIDDEN: "해당 페이지에 접근 권한이 없습니다.",
   UNAUTHORIZED: "인증되지 않은 유저입니다.",
+  NOT_VALID_USER: "해당 유저가 존재하지 않습니다.",
 });
 
 module.exports = ERROR_MESSAGE;

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -154,7 +154,7 @@ const inviteNewMember = async (req, res, next) => {
     }
 
     const invitationToken = jwt.sign({ email }, INVITATION_SECRET_KEY, {
-      expiresIn: 60,
+      expiresIn: "2d",
     });
 
     const invitationUrl = `http://localhost:3000/my-travels/${id}/invitation/${invitationToken}`;

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -1,7 +1,12 @@
+const jwt = require("jsonwebtoken");
+const nodemailer = require("nodemailer");
+
 const Map = require("../models/Map");
 const User = require("../models/User");
 
 const ERROR_MESSAGE = require("../constants");
+
+const { INVITATION_MAIL, INVITATION_PASSWORD } = process.env;
 
 const getMapPoints = async (req, res, next) => {
   const { id } = req.params;
@@ -110,7 +115,87 @@ const addInvitedUser = async (req, res, next) => {
   }
 };
 
+const inviteNewMember = async (req, res, next) => {
+  const { id } = req.params;
+  const { email } = req.body;
+
+  try {
+    const currentMap = await Map.findById(id).exec();
+    const newUser = await User.findOne({ email }).exec();
+
+    const userId = newUser._id;
+    const verifyInvitedEmail = currentMap.invitationList
+      .map(user => user.email)
+      .some(invitedEmail => invitedEmail === email);
+
+    if (!newUser) {
+      res.json({
+        message: "등록되지 않은 유저입니다.",
+      });
+      return;
+    }
+
+    if (currentMap.members.some(member => member.equals(userId))) {
+      res.json({
+        message: "이미 같은 그룹 멤버입니다.",
+      });
+      return;
+    }
+
+    if (verifyInvitedEmail) {
+      res.json({
+        message: "이미 초대 메일을 보낸 유저입니다.",
+      });
+      return;
+    }
+
+    const invitationToken = jwt.sign(
+      { email },
+      process.env.INVITATION_SECRET_KEY,
+      {
+        expiresIn: "2d",
+      }
+    );
+
+    const invitationUrl = `http://localhost:3000/my-travels/${id}/invitation/${invitationToken}`;
+
+    const transporter = nodemailer.createTransport({
+      service: "gmail",
+      auth: {
+        user: INVITATION_MAIL,
+        pass: INVITATION_PASSWORD,
+      },
+    });
+
+    const sendMail = transporter.sendMail({
+      from: INVITATION_MAIL,
+      to: email,
+      subject: "[OCN] 그룹 초대 메일",
+      html: `<p> 아래 링크를 누르면 그룹으로 초대 됩니다 </p> <a href=${invitationUrl} >초대링크</a>`,
+    });
+
+    currentMap.invitationList.push({
+      email,
+      token: invitationToken,
+    });
+
+    await Promise.all([sendMail, currentMap.save()]);
+
+    res.json({
+      result: "메일 발송 성공",
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
 exports.getMapPoints = getMapPoints;
 exports.createNewMap = createNewMap;
 exports.getMembers = getMembers;
 exports.addInvitedUser = addInvitedUser;
+exports.inviteNewMember = inviteNewMember;

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -132,6 +132,7 @@ const inviteNewMember = async (req, res, next) => {
       res.json({
         result: "등록되지 않은 유저입니다.",
       });
+
       return;
     }
 
@@ -139,6 +140,7 @@ const inviteNewMember = async (req, res, next) => {
       res.json({
         result: "이미 같은 그룹 멤버입니다.",
       });
+
       return;
     }
 
@@ -146,6 +148,7 @@ const inviteNewMember = async (req, res, next) => {
       res.json({
         result: "이미 초대 메일을 보낸 유저입니다.",
       });
+
       return;
     }
 

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -133,7 +133,7 @@ const inviteNewMember = async (req, res, next) => {
     }
 
     const userId = invitedUser._id;
-    const invitedEmail = currentMap.invitationList
+    const isInvitedEmail = currentMap.invitationList
       .map(user => user.email)
       .includes(email);
 
@@ -145,7 +145,7 @@ const inviteNewMember = async (req, res, next) => {
       return;
     }
 
-    if (invitedEmail) {
+    if (isInvitedEmail) {
       res.json({
         result: RESPONSE_MESSAGE.ALREADY_INVITED,
       });

--- a/controllers/mapController.js
+++ b/controllers/mapController.js
@@ -130,21 +130,21 @@ const inviteNewMember = async (req, res, next) => {
 
     if (!newUser) {
       res.json({
-        message: "등록되지 않은 유저입니다.",
+        result: "등록되지 않은 유저입니다.",
       });
       return;
     }
 
     if (currentMap.members.some(member => member.equals(userId))) {
       res.json({
-        message: "이미 같은 그룹 멤버입니다.",
+        result: "이미 같은 그룹 멤버입니다.",
       });
       return;
     }
 
     if (verifyInvitedEmail) {
       res.json({
-        message: "이미 초대 메일을 보낸 유저입니다.",
+        result: "이미 초대 메일을 보낸 유저입니다.",
       });
       return;
     }

--- a/middlewares/inviteTokenValidation.js
+++ b/middlewares/inviteTokenValidation.js
@@ -13,7 +13,7 @@ const validateInviteToken = async (req, res, next) => {
 
     const verifyToken = token => {
       try {
-        return jwt.verify(token, INVITATION_SECRET_KEY).hasOwnProperty("email");
+        return jwt.verify(token, INVITATION_SECRET_KEY);
       } catch {
         return false;
       }
@@ -27,7 +27,7 @@ const validateInviteToken = async (req, res, next) => {
     await currentMap.save();
 
     next();
-  } catch (error) {
+  } catch {
     res.json({
       error: {
         message: ERROR_MESSAGE.SERVER_ERROR,

--- a/middlewares/inviteTokenValidation.js
+++ b/middlewares/inviteTokenValidation.js
@@ -1,0 +1,39 @@
+const jwt = require("jsonwebtoken");
+const Map = require("../models/Map");
+
+const { INVITATION_SECRET_KEY } = process.env;
+const { ERROR_MESSAGE } = require("../constants");
+
+const validateInviteToken = async (req, res, next) => {
+  const { id } = req.params;
+
+  try {
+    const currentMap = await Map.findById(id).exec();
+
+    const verifyToken = token => {
+      try {
+        return jwt.verify(token, INVITATION_SECRET_KEY).hasOwnProperty("email");
+      } catch {
+        return false;
+      }
+    };
+
+    const filteredInvitationList = currentMap.invitationList.filter(item =>
+      verifyToken(item.token)
+    );
+
+    currentMap.set("invitationList", filteredInvitationList);
+    await currentMap.save();
+
+    next();
+  } catch (error) {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+exports.validateInviteToken = validateInviteToken;

--- a/middlewares/inviteTokenValidation.js
+++ b/middlewares/inviteTokenValidation.js
@@ -1,8 +1,9 @@
 const jwt = require("jsonwebtoken");
 const Map = require("../models/Map");
 
-const { INVITATION_SECRET_KEY } = process.env;
 const { ERROR_MESSAGE } = require("../constants");
+
+const { INVITATION_SECRET_KEY } = process.env;
 
 const validateInviteToken = async (req, res, next) => {
   const { id } = req.params;

--- a/middlewares/inviteValidation.js
+++ b/middlewares/inviteValidation.js
@@ -4,11 +4,10 @@ const ERROR_MESSAGE = require("../constants");
 
 const validateInvitation = (req, res, next) => {
   const { token } = req.params;
-  const { INVITATION_SECRET_KEY, REFRESH_SECRET_KEY } = process.env;
+  const { INVITATION_SECRET_KEY } = process.env;
 
   try {
-    // res.locals.userEmail = jwt.verify(token, INVITATION_SECRET_KEY).email;
-    res.locals.userEmail = jwt.verify(token, REFRESH_SECRET_KEY).email;
+    res.locals.userEmail = jwt.verify(token, INVITATION_SECRET_KEY).email;
 
     next();
   } catch (error) {

--- a/middlewares/memberValidation.js
+++ b/middlewares/memberValidation.js
@@ -21,7 +21,7 @@ const validateMember = async (req, res, next) => {
       .lean()
       .exec();
 
-    const existMap = userMaps.find(map => map._id === id);
+    const existMap = userMaps.find(map => map._id.equals(id));
 
     if (existMap) {
       next();

--- a/routes/map.js
+++ b/routes/map.js
@@ -18,6 +18,8 @@ router.get(
 );
 router.post("/new", mapController.createNewMap);
 router.get("/:id/members", validateId, mapController.getMembers);
+
+router.put("/:id/invitation", validateId, mapController.inviteNewMember);
 router.put(
   "/:id/invitation/:token",
   validateId,

--- a/routes/map.js
+++ b/routes/map.js
@@ -4,6 +4,7 @@ const { validateId } = require("../middlewares/objectIdValidation");
 const { validateToken } = require("../middlewares/userValidation");
 const { validateMember } = require("../middlewares/memberValidation");
 const { validateInvitation } = require("../middlewares/inviteValidation");
+const { validateInviteToken } = require("../middlewares/inviteTokenValidation");
 
 const mapController = require("../controllers/mapController");
 
@@ -19,7 +20,12 @@ router.get(
 router.post("/new", mapController.createNewMap);
 router.get("/:id/members", validateId, mapController.getMembers);
 
-router.put("/:id/invitation", validateId, mapController.inviteNewMember);
+router.put(
+  "/:id/invitation",
+  validateId,
+  validateInviteToken,
+  mapController.inviteNewMember
+);
 router.put(
   "/:id/invitation/:token",
   validateId,


### PR DESCRIPTION
# [13] [BE] 새로운 멤버 초대하기

## 노션 칸반 링크
- [[BE] 새로운 멤버 초대하기](https://www.notion.so/vanillacoding/BE-edeb1022d7174740b4f2fdff51ed84b9)
​
## 카드에서 구현 혹은 해결하려는 내용
- req.body로 넘겨받은 이메일로 해당 그룹의 초대메일을 발송 (nodemailer이용)
- 초대메일을 보내고, map 스키마에 존재하는 invitationList에 이메일과 jwt token을 저장
​
## 테스트 방법
- postman을 통해 각 조건 (회원가입 된 user? 이미 그룹 멤버? 이미 초대 메일을 보낸 유저? 등) 확인 검증
- email 잘 전송됨, 초대링크 클릭시 잘 넘어옴

## 기타 사항
- 조건에 맞는 분기처리 때문에 조금 가독성이 좋지 않은 것 같습니다..
- 네이밍이 좀 명확하지 않은 것 같아요.. 특히 newUser 부분이 애매한 것 같은데 좋은 네이밍이 있을까요?..? newlyInvitedUser는 너무 긴 것 같죠??
- 조건마다 보내주는 result를 상수처리 해주지 않고 있는데 통일하는게 좋을까요? 아님 4xx에러라고 볼 수 있을까요?
- sendMail 함수에서 보낼 메일을 주저리주저리 작성하고 있는데, 분리해서 다른 파일을 만드는 것이 좋을까요? ?
- 메일 내용 style적인 부분은 아직 못했습니다ㅠㅠ 리팩토링 때 해보는 건 어떠세요?