### PR TITLE
# [#22-1] [BE] 사진 데이터 전체 가져오기 (#22로직 삭제 #17로직 변경)

### DIFF
--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -4,23 +4,6 @@ const Photo = require("../models/Photo");
 const Point = require("../models/Point");
 const { ERROR_MESSAGE } = require("../constants");
 
-const getPhoto = async (req, res, next) => {
-  const { id } = req.params;
-
-  try {
-    const photo = await Photo.findById(id).populate("comments").lean().exec();
-
-    res.json({ photo });
-  } catch {
-    res.json({
-      error: {
-        message: ERROR_MESSAGE.SERVER_ERROR,
-        code: 500,
-      },
-    });
-  }
-};
-
 const deletePhoto = async (req, res, next) => {
   const { id: photoId } = req.params;
   const { point: pointId } = url.parse(req.url, true).query;
@@ -61,6 +44,5 @@ const deletePhoto = async (req, res, next) => {
 
 const uploadPhoto = (req, res, next) => {};
 
-exports.getPhoto = getPhoto;
 exports.deletePhoto = deletePhoto;
 exports.uploadPhoto = uploadPhoto;

--- a/controllers/pointController.js
+++ b/controllers/pointController.js
@@ -9,17 +9,33 @@ const getPhotos = async (req, res, next) => {
 
   try {
     const { photos: dbPhotos } = await Point.findOne({ latitude, longitude })
-      .populate("photos", "_id createdAt url description")
+      .populate({
+        path: "photos",
+        populate: { path: "comments", model: "Comment" },
+      })
       .lean()
       .exec();
 
     const photos = dbPhotos
-      .map(({ _id: id, createdAt, url, description }) => ({
-        id,
-        createdAt,
-        url,
-        description,
-      }))
+      .map(
+        ({
+          _id: id,
+          createdAt,
+          createdBy,
+          url,
+          placeName,
+          description,
+          comments,
+        }) => ({
+          id,
+          createdAt,
+          createdBy,
+          url,
+          placeName,
+          description,
+          comments,
+        })
+      )
       .sort((a, b) => b.createdAt - a.createdAt);
 
     res.json({ photos });

--- a/routes/photo.js
+++ b/routes/photo.js
@@ -2,11 +2,9 @@ const express = require("express");
 
 const photoController = require("../controllers/photoController");
 const { deleteServerImg } = require("../middlewares/awsS3");
-const { validateId } = require("../middlewares/objectIdValidation");
 
 const router = express.Router();
 
-router.get("/:id", validateId, photoController.getPhoto);
 router.delete("/:id", deleteServerImg, photoController.deletePhoto);
 
 module.exports = router;


### PR DESCRIPTION
# [#22-1] [BE] 사진 데이터 전체 가져오기 (#22로직 삭제 #17로직 변경)

## 노션 칸반 링크

- [[BE] [BE] 사진 데이터 전체 가져오기 (#22로직 삭제 + #17로직 변경)
  ](https://www.notion.so/vanillacoding/BE-86558702e2a640b1abd2e8556464fb28)

## 카드에서 구현 혹은 해결하려는 내용

- query 값을 이용하여 해당 포인트에 저장된 사진의 상세정보들을 응답으로 내주기(#22번 태스크 로직 삭제, #17번 태스크 로직 변경)

## 테스트 방법

- mok 데이터, postman, 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- 함께 논의 한대로 아래와 같이 수정완료 하였습니다.
- (변경사항): #17번 photo데이터 포토카드 형식 렌더링에 필요한 정보 내주기와 #22번 사진디테일 페이지 랜더링 시 해당 사진의 comments 정보를 내주는 작업을 나누어 요청이 여러번 진행되게 로직을 작성하였으나, 관련있는 데이터를 한번에 캐싱하여 서버요청의 횟수를 줄일 수 있는 방향으로 로직을 변경하였습니다.
