### PR TITLE
#26 Board 게시글 저장 & 전체 게시글 랜더링 & 필터링 검색(지역, 해시태그)

### DIFF
--- a/app.js
+++ b/app.js
@@ -15,6 +15,7 @@ const map = require("./routes/map");
 const point = require("./routes/point");
 const photo = require("./routes/photo");
 const comment = require("./routes/comment");
+const posting = require("./routes/posting");
 
 const app = express();
 
@@ -37,6 +38,7 @@ app.use("/map", map);
 app.use("/point", point);
 app.use("/photo", photo);
 app.use("/comment", comment);
+app.use("/posting", posting);
 
 app.use((req, res, next) => {
   next(createError(404, ERROR_MESSAGE.NOT_FOUND));

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -7,51 +7,6 @@ const Comment = require("../models/Comment");
 
 const { ERROR_MESSAGE } = require("../constants");
 
-const getPhotos = async (req, res, next) => {
-  const { id: photoId } = req.params;
-  try {
-    const { point: pointId } = await Photo.findById(photoId).exec();
-    const { photos: dbPhotos } = await Point.findById(pointId)
-      .populate({
-        path: "photos",
-        populate: { path: "comments", model: "Comment" },
-      })
-      .lean()
-      .exec();
-
-    const photos = dbPhotos
-      .map(
-        ({
-          _id: id,
-          createdAt,
-          createdBy,
-          url,
-          placeName,
-          description,
-          comments,
-        }) => ({
-          id,
-          createdAt,
-          createdBy,
-          url,
-          placeName,
-          description,
-          comments,
-        })
-      )
-      .sort((a, b) => b.createdAt - a.createdAt);
-
-    res.json({ photos });
-  } catch {
-    res.json({
-      error: {
-        message: ERROR_MESSAGE.SERVER_ERROR,
-        code: 500,
-      },
-    });
-  }
-};
-
 const uploadPhoto = async (req, res, next) => {
   const { photo, point, description, map } = req.body;
   const { createdAt, createdBy } = JSON.parse(photo);
@@ -185,6 +140,5 @@ const deletePhoto = async (req, res, next) => {
   }
 };
 
-exports.getPhotos = getPhotos;
 exports.uploadPhoto = uploadPhoto;
 exports.deletePhoto = deletePhoto;

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -75,10 +75,10 @@ const deletePhoto = async (req, res, next) => {
   const { map: mapId } = url.parse(req.url, true).query;
 
   try {
-    const currentMap = await Map.findById(mapId).exec();
-    const currentPhoto = await Photo.findById(photoId)
-      .populate("comments")
-      .exec();
+    const [currentMap, currentPhoto] = await Promise.all([
+      Map.findById(mapId).exec(),
+      Photo.findById(photoId).populate("comments").exec(),
+    ]);
 
     const { points: pointsInMap, photos: photosInMap } = currentMap;
     const { comments, point: pointInPhoto } = currentPhoto;

--- a/controllers/pointController.js
+++ b/controllers/pointController.js
@@ -8,6 +8,13 @@ const getPhotos = async (req, res, next) => {
   const { latitude, longitude } = url.parse(req.url, true).query;
 
   try {
+    const point = await Point.findOne({ latitude, longitude }).exec();
+
+    if (!point) {
+      res.json({ photos: [] });
+      return;
+    }
+
     const { photos: dbPhotos } = await Point.findOne({ latitude, longitude })
       .populate({
         path: "photos",

--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -1,0 +1,115 @@
+const Posting = require("../models/Posting");
+const User = require("../models/User");
+
+const { ERROR_MESSAGE } = require("../constants");
+
+const getPostings = async (req, res, next) => {
+  let postings;
+  const pageSize = 5;
+  const page = parseInt(req.query.page, 10) || "0";
+
+  try {
+    const countPostings = await Posting.countDocuments({}).exec();
+    const totalPostings = await Posting.find({}).exec();
+    const startPosting = countPostings - pageSize * (page - 1);
+    const endPosting = countPostings - pageSize * page;
+
+    if (countPostings - pageSize * (page - 1) <= pageSize) {
+      postings = totalPostings.slice(0, startPosting).reverse();
+    } else {
+      postings = totalPostings.slice(endPosting, startPosting).reverse();
+    }
+
+    res.json({
+      postings,
+      totalPages: Math.ceil(countPostings / pageSize),
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+const searchPostings = async (req, res, next) => {
+  const pageSize = 3;
+  const { region, hashtag, page } = req.query;
+
+  let countFilteredPostings;
+  let filteredPostings;
+  let totalFilteredPostings;
+
+  try {
+    if (region && hashtag) {
+      [countFilteredPostings, filteredPostings] = await Promise.all([
+        Posting.countDocuments({ regions: region, hashtags: hashtag.trim() }),
+        Posting.find({ regions: region, hashtags: hashtag.trim() }),
+      ]);
+    } else if (region && !hashtag) {
+      [countFilteredPostings, filteredPostings] = await Promise.all([
+        Posting.countDocuments({ regions: region }),
+        Posting.find({ regions: region }),
+      ]);
+    } else {
+      [countFilteredPostings, filteredPostings] = await Promise.all([
+        Posting.countDocuments({ hashtags: hashtag.trim() }),
+        Posting.find({ hashtags: hashtag.trim() }),
+      ]);
+    }
+
+    const startPosting = countFilteredPostings - pageSize * (page - 1);
+    const endPosting = countFilteredPostings - pageSize * page;
+
+    if (countFilteredPostings - pageSize * (page - 1) <= pageSize) {
+      totalFilteredPostings = filteredPostings.slice(0, startPosting).reverse();
+    } else {
+      totalFilteredPostings = filteredPostings
+        .slice(endPosting, startPosting)
+        .reverse();
+    }
+
+    res.json({
+      postings: totalFilteredPostings,
+      totalPages: Math.ceil(countFilteredPostings / pageSize),
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+const createPosting = async (req, res, next) => {
+  const { posting, user: userId } = req.body;
+
+  try {
+    const newPosting = await new Posting(posting);
+    const currentUser = await User.findById(userId).exec();
+
+    const newPostingId = newPosting._id;
+    currentUser.myPostings.push(newPostingId);
+
+    await Promise.all([currentUser.save(), newPosting.save()]);
+
+    res.json({
+      result: "ok",
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+exports.getPostings = getPostings;
+exports.searchPostings = searchPostings;
+exports.createPosting = createPosting;

--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -5,19 +5,19 @@ const { ERROR_MESSAGE } = require("../constants");
 
 const getPostings = async (req, res, next) => {
   let postings;
-  const pageSize = 5;
+  const pageSize = 8;
   const page = parseInt(req.query.page, 10) || "0";
 
   try {
     const countPostings = await Posting.countDocuments({}).exec();
     const totalPostings = await Posting.find({}).exec();
-    const startPosting = countPostings - pageSize * (page - 1);
-    const endPosting = countPostings - pageSize * page;
+    const startIndex = countPostings - pageSize * (page - 1);
+    const endIndex = countPostings - pageSize * page;
 
     if (countPostings - pageSize * (page - 1) <= pageSize) {
-      postings = totalPostings.slice(0, startPosting).reverse();
+      postings = totalPostings.slice(0, startIndex).reverse();
     } else {
-      postings = totalPostings.slice(endPosting, startPosting).reverse();
+      postings = totalPostings.slice(endIndex, startIndex).reverse();
     }
 
     res.json({
@@ -35,45 +35,45 @@ const getPostings = async (req, res, next) => {
 };
 
 const searchPostings = async (req, res, next) => {
-  const pageSize = 3;
+  const pageSize = 8;
   const { region, hashtag, page } = req.query;
 
-  let countFilteredPostings;
+  let filteredPostingCount;
   let filteredPostings;
   let totalFilteredPostings;
 
   try {
     if (region && hashtag) {
-      [countFilteredPostings, filteredPostings] = await Promise.all([
+      [filteredPostingCount, filteredPostings] = await Promise.all([
         Posting.countDocuments({ regions: region, hashtags: hashtag.trim() }),
         Posting.find({ regions: region, hashtags: hashtag.trim() }),
       ]);
     } else if (region && !hashtag) {
-      [countFilteredPostings, filteredPostings] = await Promise.all([
+      [filteredPostingCount, filteredPostings] = await Promise.all([
         Posting.countDocuments({ regions: region }),
         Posting.find({ regions: region }),
       ]);
     } else {
-      [countFilteredPostings, filteredPostings] = await Promise.all([
+      [filteredPostingCount, filteredPostings] = await Promise.all([
         Posting.countDocuments({ hashtags: hashtag.trim() }),
         Posting.find({ hashtags: hashtag.trim() }),
       ]);
     }
 
-    const startPosting = countFilteredPostings - pageSize * (page - 1);
-    const endPosting = countFilteredPostings - pageSize * page;
+    const startIndex = filteredPostingCount - pageSize * (page - 1);
+    const endIndex = filteredPostingCount - pageSize * page;
 
-    if (countFilteredPostings - pageSize * (page - 1) <= pageSize) {
-      totalFilteredPostings = filteredPostings.slice(0, startPosting).reverse();
+    if (filteredPostingCount - pageSize * (page - 1) <= pageSize) {
+      totalFilteredPostings = filteredPostings.slice(0, startIndex).reverse();
     } else {
       totalFilteredPostings = filteredPostings
-        .slice(endPosting, startPosting)
+        .slice(endIndex, startIndex)
         .reverse();
     }
 
     res.json({
       postings: totalFilteredPostings,
-      totalPages: Math.ceil(countFilteredPostings / pageSize),
+      totalPages: Math.ceil(filteredPostingCount / pageSize),
     });
   } catch {
     res.json({

--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -9,12 +9,12 @@ const getPostings = async (req, res, next) => {
   const page = parseInt(req.query.page, 10) || "0";
 
   try {
-    const countPostings = await Posting.countDocuments({}).exec();
+    const postingCount = await Posting.countDocuments({}).exec();
     const totalPostings = await Posting.find({}).exec();
-    const startIndex = countPostings - pageSize * (page - 1);
-    const endIndex = countPostings - pageSize * page;
+    const startIndex = postingCount - pageSize * (page - 1);
+    const endIndex = postingCount - pageSize * page;
 
-    if (countPostings - pageSize * (page - 1) <= pageSize) {
+    if (postingCount - pageSize * (page - 1) <= pageSize) {
       postings = totalPostings.slice(0, startIndex).reverse();
     } else {
       postings = totalPostings.slice(endIndex, startIndex).reverse();
@@ -22,7 +22,7 @@ const getPostings = async (req, res, next) => {
 
     res.json({
       postings,
-      totalPages: Math.ceil(countPostings / pageSize),
+      totalPages: Math.ceil(postingCount / pageSize),
     });
   } catch {
     res.json({

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -58,13 +58,33 @@ const photoValidators = [
     .trim()
     .isURL()
     .withMessage(ERROR_MESSAGE.URL_REQUIRED),
-  body("point.placeName")
+  body("photo.placeName")
     .exists()
     .withMessage(ERROR_MESSAGE.PLACENAME_REQUIRED),
-  body("point.point")
+  body("photo.point")
     .exists()
     .isObject()
     .withMessage(ERROR_MESSAGE.POINT_REQUIRED),
+];
+
+const postingInputValidators = [
+  body("posting.title")
+    .trim()
+    .notEmpty()
+    .withMessage(ERROR_MESSAGE.TITLE_REQUIRED),
+  body("posting.content")
+    .exists()
+    .trim()
+    .notEmpty()
+    .withMessage(ERROR_MESSAGE.MESSAGE_REQUIRED),
+  body("posting.hashtags")
+    .exists()
+    .isLength({ min: 1, max: 5 })
+    .withMessage(ERROR_MESSAGE.HASHTAGS_COUNT_LIMIT),
+  body("posting.regions")
+    .exists()
+    .isLength({ min: 1, max: 3 })
+    .withMessage(ERROR_MESSAGE.REGIONS_COUNT_LIMIT),
 ];
 
 const validate = validations => {
@@ -99,4 +119,5 @@ exports.commentInputValidator = commentInputValidator;
 exports.signUpInputValidators = signUpInputValidators;
 exports.pointValidators = pointValidators;
 exports.photoValidators = photoValidators;
+exports.postingInputValidators = postingInputValidators;
 exports.validate = validate;

--- a/routes/photo.js
+++ b/routes/photo.js
@@ -14,6 +14,5 @@ router.post(
   photoController.uploadPhoto
 );
 router.delete("/:id", deleteServerImg, photoController.deletePhoto);
-router.get("/:id", photoController.getPhotos);
 
 module.exports = router;

--- a/routes/photo.js
+++ b/routes/photo.js
@@ -14,5 +14,6 @@ router.post(
   photoController.uploadPhoto
 );
 router.delete("/:id", deleteServerImg, photoController.deletePhoto);
+router.get("/:id", photoController.getPhotos);
 
 module.exports = router;

--- a/routes/posting.js
+++ b/routes/posting.js
@@ -1,0 +1,20 @@
+const express = require("express");
+
+const {
+  validate,
+  postingInputValidators,
+} = require("../middlewares/inputValidation");
+
+const postingController = require("../controllers/postingController");
+
+const router = express.Router();
+
+router.get("/", postingController.getPostings);
+router.get("/search", postingController.searchPostings);
+router.post(
+  "/new",
+  validate(postingInputValidators),
+  postingController.createPosting
+);
+
+module.exports = router;


### PR DESCRIPTION
# [#26] [FE] 게시글 저장 &랜더링 & 필터링 (지역, 해시태그)

## 노션 칸반 링크
- [Board 게시글 저장](https://www.notion.so/vanillacoding/BE-Board-451d27ad3ff44a6b873fbf8be77b0d7f)
- [Board 전체 게시글 랜더링](https://www.notion.so/vanillacoding/BE-Board-6b4cc2a0a1434474b8d1241820973f64)
- [게시글 필터링 검색(지역, 해시태그)](https://www.notion.so/vanillacoding/BE-028d3f0394dc4362921e1a00a04adda5)
​
## 카드에서 구현 혹은 해결하려는 내용
- posting 생성 & 전체 게시글 렌더링 & 게시글 필터링 (지역, 해시태그) 기능 구현
- 관련 DB 모두 업데이트
​
## 테스트 방법
- postman을 통해 검증 확인 -> OK

## 기타 사항
- pagination부분을 mongoose 메소드를 사용하지 않고, 효율성을 위해서 다른 방법으로 구현했습니다.
- 기능구현에 집중하여 validation이 괜찮을지 걱정이 됩니다. 이부분 확인 부탁드려요~!