### PR TITLE
# [#34] [BE] 내 포스팅 불러오기

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -26,4 +26,53 @@ const getUserMaps = async (req, res, next) => {
   }
 };
 
+const getUserPostings = async (req, res, next) => {
+  const { id: userId } = req.params;
+  const page = parseInt(req.query.page, 10) || 0;
+  const pageSize = 8;
+
+  try {
+    const { myPostings } = await User.findById(userId)
+      .populate("myPostings")
+      .select({
+        _id: 0,
+        myPostings: 1,
+      })
+      .lean()
+      .exec();
+
+    const filteredPostings = myPostings.map(posting => ({
+      id: posting._id,
+      title: posting.title,
+      createdBy: posting.createdBy,
+      createdAt: posting.createdAt,
+    }));
+
+    const totalCount = myPostings.length;
+    const startIndex = totalCount - pageSize * (page - 1);
+    const endIndex = totalCount - pageSize * page;
+
+    let postings;
+
+    if (totalCount - pageSize * (page - 1) <= pageSize) {
+      postings = filteredPostings.slice(0, startIndex).reverse();
+    } else {
+      postings = filteredPostings.slice(endIndex, startIndex).reverse();
+    }
+
+    res.json({
+      postings,
+      totalPages: Math.ceil(totalCount / pageSize),
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+exports.getUserPostings = getUserPostings;
 exports.getUserMaps = getUserMaps;

--- a/routes/user.js
+++ b/routes/user.js
@@ -1,10 +1,12 @@
 const express = require("express");
 
-const { validateToken } = require("../middlewares/userValidation");
 const userController = require("../controllers/userController");
+const { validateToken } = require("../middlewares/userValidation");
+const { validateId } = require("../middlewares/objectIdValidation");
 
 const router = express.Router();
 
-router.get("/:id/maps", validateToken, userController.getUserMaps);
+router.get("/:id/maps", validateId, validateToken, userController.getUserMaps);
+router.get("/:id/postings", validateId, userController.getUserPostings);
 
 module.exports = router;


### PR DESCRIPTION
# [#34] [BE] 내 포스팅 불러오기

## 노션 칸반 링크

- [[BE] 내 포스팅 불러오기
  ](https://www.notion.so/vanillacoding/BE-bfbf4aa6148140cba7aba89b4f8337a0)

## 카드에서 구현 혹은 해결하려는 내용

- req.params 유저 id 값 활용 유저 myPostings 목록 8개씩 응답으로 내주기(query 로 넘겨받는 페이지번호 활용)

## 테스트 방법

- mok 데이터, postman, 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- 기존 칸반에 응답으로 내주기로 했던 imageUrl 값을 Posting Schema 필드에 포함되어 있지 않아 현재는 Url 값을 제외한 값들을 응답으로 보내주고 있습니다.
- tokenValidation 미들웨어는 추후 완성단계에서 넣기로 함께 논의하여 넣지 않았습니다.
