### PR TITLE
# [#36] [BE] Posting 데이터 삭제

### DIFF
--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -129,7 +129,31 @@ const createPosting = async (req, res, next) => {
   }
 };
 
+const deletePosting = async (req, res, next) => {
+  const { id: postingId } = req.params;
+  const userId = req.query.user;
+
+  try {
+    await Promise.all([
+      User.updateOne({ _id: userId }, { $pull: { myPostings: postingId } }),
+      Posting.deleteOne({ _id: postingId }),
+    ]);
+
+    res.json({
+      result: "ok",
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
 exports.getPostings = getPostings;
 exports.getPostingDetail = getPostingDetail;
 exports.searchPostings = searchPostings;
 exports.createPosting = createPosting;
+exports.deletePosting = deletePosting;

--- a/routes/posting.js
+++ b/routes/posting.js
@@ -18,5 +18,6 @@ router.post(
   validate(postingInputValidators),
   postingController.createPosting
 );
+router.delete("/:id", validateId, postingController.deletePosting);
 
 module.exports = router;


### PR DESCRIPTION
# [#36] [BE] Posting 데이터 삭제

## 노션 칸반 링크

- [[BE] Posting 데이터 삭제
  ](https://www.notion.so/vanillacoding/BE-Posting-5c8ed2f110254c848620b14bd6cacc5b)

## 카드에서 구현 혹은 해결하려는 내용

- req.params 포스팅 id, req.query 유저 id 값 활용하여 해당 posting 데이터를 삭제
  - 해당 User 데이터 내 myPostings 데이터 중 해당 posting id 제거하여 업데이트
  - Posting 데이터 삭제

## 테스트 방법

- mok 데이터, postman, 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- tokenValidation은 추후 완성단계에서 넣기로 함께 논의하였으므로 미들웨어로 넣지 않았습니다.
