### PR TITLE
# [#37] [BE] Posting 데이터 업데이트

### DIFF
--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -53,6 +53,60 @@ const getPostingDetail = async (req, res, next) => {
   }
 };
 
+const updatePosting = async (req, res, next) => {
+  const { id: postingId } = req.params;
+  const { posting } = req.body;
+
+  const { title, content, hashtags, regions, logOption } = posting;
+
+  try {
+    await Posting.updateOne(
+      { _id: postingId },
+      {
+        title,
+        content,
+        hashtags,
+        regions,
+        logOption,
+      }
+    );
+
+    res.json({
+      result: "ok",
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
+const deletePosting = async (req, res, next) => {
+  const { id: postingId } = req.params;
+  const userId = req.query.user;
+
+  try {
+    await Promise.all([
+      User.updateOne({ _id: userId }, { $pull: { myPostings: postingId } }),
+      Posting.deleteOne({ _id: postingId }),
+    ]);
+
+    res.json({
+      result: "ok",
+    });
+  } catch {
+    res.json({
+      error: {
+        message: ERROR_MESSAGE.SERVER_ERROR,
+        code: 500,
+      },
+    });
+  }
+};
+
 const searchPostings = async (req, res, next) => {
   const pageSize = 8;
   const { region, hashtag, page } = req.query;
@@ -129,31 +183,9 @@ const createPosting = async (req, res, next) => {
   }
 };
 
-const deletePosting = async (req, res, next) => {
-  const { id: postingId } = req.params;
-  const userId = req.query.user;
-
-  try {
-    await Promise.all([
-      User.updateOne({ _id: userId }, { $pull: { myPostings: postingId } }),
-      Posting.deleteOne({ _id: postingId }),
-    ]);
-
-    res.json({
-      result: "ok",
-    });
-  } catch {
-    res.json({
-      error: {
-        message: ERROR_MESSAGE.SERVER_ERROR,
-        code: 500,
-      },
-    });
-  }
-};
-
 exports.getPostings = getPostings;
+exports.deletePosting = deletePosting;
+exports.updatePosting = updatePosting;
 exports.getPostingDetail = getPostingDetail;
 exports.searchPostings = searchPostings;
 exports.createPosting = createPosting;
-exports.deletePosting = deletePosting;

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -79,11 +79,11 @@ const postingInputValidators = [
     .withMessage(ERROR_MESSAGE.MESSAGE_REQUIRED),
   body("posting.hashtags")
     .exists()
-    .isLength({ min: 1, max: 5 })
+    .isArray({ min: 1, max: 5 })
     .withMessage(ERROR_MESSAGE.HASHTAGS_COUNT_LIMIT),
   body("posting.regions")
     .exists()
-    .isLength({ min: 1, max: 3 })
+    .isArray({ min: 1, max: 3 })
     .withMessage(ERROR_MESSAGE.REGIONS_COUNT_LIMIT),
 ];
 

--- a/routes/posting.js
+++ b/routes/posting.js
@@ -12,12 +12,19 @@ const router = express.Router();
 
 router.get("/", postingController.getPostings);
 router.get("/:id", validateId, postingController.getPostingDetail);
+router.put(
+  "/:id",
+  validateId,
+  validate(postingInputValidators),
+  postingController.updatePosting
+);
+router.delete("/:id", validateId, postingController.deletePosting);
+
 router.get("/search", postingController.searchPostings);
 router.post(
   "/new",
   validate(postingInputValidators),
   postingController.createPosting
 );
-router.delete("/:id", validateId, postingController.deletePosting);
 
 module.exports = router;


### PR DESCRIPTION
# [#37] [BE] Posting 데이터 업데이트

## 노션 칸반 링크

- [[BE] Posting 데이터 업데이트
  ](https://www.notion.so/vanillacoding/BE-Posting-d7aa7efdbca14036bd8eee9c342783f3)

## 카드에서 구현 혹은 해결하려는 내용

- req.body로 받는 posting 데이터와 req.params의 posting id로 해당 게시글 데이터 수정하기

## 테스트 방법

- mok 데이터, postman, 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- 클라이언트로부터 받는 요청의 body 값 변경하였습니다. 칸반 혹은 코드를 통해 확인 부탁드립니다:)
  - posting input 에 대한 validation 을 위해 검증 미들웨어에서 받는 body 형태에 맞추어 변경하였습니다.(posting 생성할 때와 같은 형태)
- postingInputValidator의 해시태그, 지역 관련 검증방법 수정하였습니다.
  - isLength -> isArray 로 변경 (배열의 길이 확인)
- tokenValidation은 추후 완성단계에서 넣기로 함께 논의하였으므로 미들웨어로 넣지 않았습니다.
