### PR TITLE
# [#34-1] [BE] pagination 로직 수정, uploadPhoto 요청핸들러 버그수정

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -27,5 +27,8 @@ const RESPONSE_MESSAGE = Object.freeze({
   ALREADY_INVITED: "이미 초대 메일을 보낸 유저입니다.",
 });
 
+const PAGE_SIZE = 8;
+
+exports.PAGE_SIZE = PAGE_SIZE;
 exports.ERROR_MESSAGE = ERROR_MESSAGE;
 exports.RESPONSE_MESSAGE = RESPONSE_MESSAGE;

--- a/controllers/photoController.js
+++ b/controllers/photoController.js
@@ -45,7 +45,11 @@ const uploadPhoto = async (req, res, next) => {
     }
 
     if (!currentPoint) {
-      const newPoint = await Point.create(point);
+      const newPoint = await Point.create({
+        latitude,
+        longitude,
+        placeName,
+      });
       const newPointId = newPoint._id;
       const newPhotoId = newPhoto._id;
 
@@ -57,6 +61,7 @@ const uploadPhoto = async (req, res, next) => {
       await Promise.all([newPhoto.save(), newPoint.save(), currentMap.save()]);
 
       res.json({
+        result: "ok",
         pointId: newPointId,
       });
     }

--- a/controllers/postingController.js
+++ b/controllers/postingController.js
@@ -1,30 +1,39 @@
 const Posting = require("../models/Posting");
 const User = require("../models/User");
 
-const { ERROR_MESSAGE } = require("../constants");
+const { PAGE_SIZE, ERROR_MESSAGE } = require("../constants");
 
 const getPostings = async (req, res, next) => {
-  let postings;
-  const pageSize = 8;
-  const page = parseInt(req.query.page, 10) || "0";
+  const pageNum = parseInt(req.query.page, 10);
+  const pageSize = PAGE_SIZE;
 
   try {
-    const postingCount = await Posting.countDocuments({}).exec();
-    const totalPostings = await Posting.find({}).exec();
-    const startIndex = postingCount - pageSize * (page - 1);
-    const endIndex = postingCount - pageSize * page;
-
-    if (postingCount - pageSize * (page - 1) <= pageSize) {
-      postings = totalPostings.slice(0, startIndex).reverse();
-    } else {
-      postings = totalPostings.slice(endIndex, startIndex).reverse();
+    if (!pageNum) {
+      throw new Error(ERROR_MESSAGE.BAD_REQUEST);
     }
+
+    const postings = await Posting.find()
+      .sort({ createdAt: -1 })
+      .skip(pageSize * (pageNum - 1))
+      .limit(pageSize)
+      .lean()
+      .exec();
 
     res.json({
       postings,
-      totalPages: Math.ceil(postingCount / pageSize),
     });
-  } catch {
+  } catch (error) {
+    if (error.message === ERROR_MESSAGE.BAD_REQUEST) {
+      res.json({
+        error: {
+          message: ERROR_MESSAGE.BAD_REQUEST,
+          code: 400,
+        },
+      });
+
+      return;
+    }
+
     res.json({
       error: {
         message: ERROR_MESSAGE.SERVER_ERROR,

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -1,5 +1,5 @@
 const User = require("../models/User");
-const ERROR_MESSAGE = require("../constants");
+const { PAGE_SIZE, ERROR_MESSAGE } = require("../constants");
 
 const getUserMaps = async (req, res, next) => {
   const { id } = req.params;
@@ -28,43 +28,49 @@ const getUserMaps = async (req, res, next) => {
 
 const getUserPostings = async (req, res, next) => {
   const { id: userId } = req.params;
-  const page = parseInt(req.query.page, 10) || 0;
-  const pageSize = 8;
+  const pageNum = parseInt(req.query.page, 10);
+  const pageSize = PAGE_SIZE;
 
   try {
+    if (!pageNum) {
+      throw new Error(ERROR_MESSAGE.BAD_REQUEST);
+    }
+
     const { myPostings } = await User.findById(userId)
-      .populate("myPostings")
-      .select({
-        _id: 0,
-        myPostings: 1,
+      .populate({
+        path: "myPostings",
+        model: "Posting",
+        options: {
+          skip: pageSize * (pageNum - 1),
+          limit: pageSize,
+        },
       })
       .lean()
       .exec();
 
-    const filteredPostings = myPostings.map(posting => ({
+    const postings = myPostings.map(posting => ({
       id: posting._id,
       title: posting.title,
       createdBy: posting.createdBy,
       createdAt: posting.createdAt,
+      imageUrl: posting.imageUrl,
     }));
-
-    const totalCount = myPostings.length;
-    const startIndex = totalCount - pageSize * (page - 1);
-    const endIndex = totalCount - pageSize * page;
-
-    let postings;
-
-    if (totalCount - pageSize * (page - 1) <= pageSize) {
-      postings = filteredPostings.slice(0, startIndex).reverse();
-    } else {
-      postings = filteredPostings.slice(endIndex, startIndex).reverse();
-    }
 
     res.json({
       postings,
-      totalPages: Math.ceil(totalCount / pageSize),
     });
-  } catch {
+  } catch (error) {
+    if (error.message === ERROR_MESSAGE.BAD_REQUEST) {
+      res.json({
+        error: {
+          message: ERROR_MESSAGE.BAD_REQUEST,
+          code: 400,
+        },
+      });
+
+      return;
+    }
+
     res.json({
       error: {
         message: ERROR_MESSAGE.SERVER_ERROR,

--- a/middlewares/inputValidation.js
+++ b/middlewares/inputValidation.js
@@ -48,23 +48,7 @@ const pointValidators = [
 ];
 
 const photoValidators = [
-  body("photo.createdAt")
-    .exists()
-    .isDate()
-    .isBefore(new Date())
-    .withMessage(ERROR_MESSAGE.VALID_DATE_REQUIRED),
-  body("photo.url")
-    .exists()
-    .trim()
-    .isURL()
-    .withMessage(ERROR_MESSAGE.URL_REQUIRED),
-  body("photo.placeName")
-    .exists()
-    .withMessage(ERROR_MESSAGE.PLACENAME_REQUIRED),
-  body("photo.point")
-    .exists()
-    .isObject()
-    .withMessage(ERROR_MESSAGE.POINT_REQUIRED),
+  body("photo").isJSON().withMessage(ERROR_MESSAGE.BAD_REQUEST),
 ];
 
 const postingInputValidators = [

--- a/models/Posting.js
+++ b/models/Posting.js
@@ -17,6 +17,11 @@ const PostingSchema = new mongoose.Schema({
     type: String,
     required: true,
   },
+  imageUrl: {
+    type: String,
+    default:
+      "https://travelphotolog.s3.ap-northeast-2.amazonaws.com/1644760423718.png",
+  },
   hashtags: [
     {
       type: String,


### PR DESCRIPTION
# [#34-1] [BE] pagination 로직 수정, uploadPhoto 요청핸들러 버그수정

## 노션 칸반 링크

- [[BE] pagination 로직 수정
  ](https://www.notion.so/vanillacoding/BE-pagenation-6412aa5d2e144154a4491f3d8f8cf28f)

## 카드에서 구현 혹은 해결하려는 내용

- 게시글 전체 정보 가져오기(#27), 유저의 게시글 정보(#34) 가져오기 시 페이지네이션 로직 수정(mongoose에서 제공하는 skip, limit 사용)
- uploadPhoto request handler 버그 수정
- inputValidations 내 photoValidators 검증내용 수정(.isJSON())

## 테스트 방법

- mok 데이터, postman, 브라우저를 활용하여 서버-클라이언트 간 요청과 응답이 원하는대로 잘 이루어지는지 확인하였습니다.

## 기타 사항

- 게시글 목록을 볼 때 필요한 imageUrl을 Posting 스키마에 필드로 추가하였습니다.
